### PR TITLE
Fix logging

### DIFF
--- a/simple_shapes_dataset/logging.py
+++ b/simple_shapes_dataset/logging.py
@@ -5,11 +5,8 @@ from typing import Any, Literal, cast
 
 from shimmer.modules.utils import (
     batch_cycles,
-    batch_cycles_with_uncertainty,
     batch_demi_cycles,
-    batch_demi_cycles_with_uncertainty,
     batch_translations,
-    batch_translations_with_uncertainty,
 )
 
 import lightning.pytorch as pl


### PR DESCRIPTION
batch functions were moved to utils but the logging code wasn't updated so no one can train a gw.

I changed the code to use the new locations. It runs fine locally but the pytest is unable to import shimmer.modules.utils I have no idea why