### PR TITLE
chore: use v4 actions in workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4 
+        uses: actions/setup-python@v5 
         with:
           python-version: "3.11.4"
       - name: Load cached Poetry install


### PR DESCRIPTION
v4 actions use a version of node that is not supported anymore. Updating to latest versions.