### PR TITLE
fix: use all dataset for `max_train_size` when adding a new alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ shapesd alignment list --dataset_path "/path/to/dataset"
 You can also filter for a particular split with e.g. `--split train` or seed 
 (e.g. `--seed 0`)
 
+If you want to restrict the size of the training set to the N first samples only, you
+can use `--max_train_size N` or `--ms N`. The same option is also available for `shapesd create`.
+
 ## Create an out of distribution split
 ```
 shapesd ood --dataset_path "/path/to/dataset" --seed 0

--- a/simple_shapes_dataset/cli/alignments.py
+++ b/simple_shapes_dataset/cli/alignments.py
@@ -18,7 +18,7 @@ def create_domain_split(
     seed: int,
     dataset_path: Path,
     domain_alignment: list[tuple[str, float]],
-    train_max_index: int = -1,
+    max_train_size: int | None = None,
 ):
     if not len(domain_alignment):
         return
@@ -40,7 +40,7 @@ def create_domain_split(
         labels = np.load(str(dataset_path / f"{split}_labels.npy"))
         allowed_indices = np.arange(labels.shape[0])
         if split == "train":
-            allowed_indices = allowed_indices[:train_max_index]
+            allowed_indices = allowed_indices[:max_train_size]
         split_name = get_deterministic_name(domain_sets, seed, allowed_indices.shape[0])
         domain_split = get_domain_alignment(
             seed,
@@ -64,8 +64,9 @@ def create_domain_split(
     help="Path to the dataset",
 )
 @click.option(
-    "--alignment_train_max_idx",
-    default=-1,
+    "--max_train_size",
+    "--ms",
+    default=None,
     type=int,
     help="Max index to use for the train set.",
 )
@@ -82,15 +83,13 @@ def create_domain_split(
 def add_alignment_split(
     seed: int,
     dataset_path: str,
-    alignment_train_max_idx: int,
+    max_train_size: int | None,
     domain_alignment: list[tuple[str, float]],
 ) -> None:
     dataset_location = Path(dataset_path)
     assert dataset_location.exists()
 
-    create_domain_split(
-        seed, dataset_location, domain_alignment, alignment_train_max_idx
-    )
+    create_domain_split(seed, dataset_location, domain_alignment, max_train_size)
 
 
 def print_table(data: Mapping[str, Sequence[str]], space: int = 2) -> str:

--- a/simple_shapes_dataset/cli/create_dataset.py
+++ b/simple_shapes_dataset/cli/create_dataset.py
@@ -105,8 +105,9 @@ def create_unpaired_attributes(
     help="Pretrained BERT model to use",
 )
 @click.option(
-    "--alignment_train_max_idx",
-    default=-1,
+    "--max_train_size",
+    "--ms",
+    default=None,
     type=int,
     help="Max index to use for the train set.",
 )
@@ -132,7 +133,7 @@ def create_dataset(
     min_lightness: int,
     max_lightness: int,
     bert_path: str,
-    alignment_train_max_idx: int,
+    max_train_size: int | None,
     domain_alignment: list[tuple[str, float]],
 ) -> None:
     dataset_location = Path(output_path)
@@ -170,9 +171,7 @@ def create_dataset(
     save_labels(dataset_location / "val_labels.npy", val_labels)
     save_labels(dataset_location / "test_labels.npy", test_labels)
 
-    create_domain_split(
-        seed, dataset_location, domain_alignment, alignment_train_max_idx
-    )
+    create_domain_split(seed, dataset_location, domain_alignment, max_train_size)
 
     print("Saving training set...")
     (dataset_location / "train").mkdir(exist_ok=True)

--- a/simple_shapes_dataset/dataset/data_module.py
+++ b/simple_shapes_dataset/dataset/data_module.py
@@ -26,7 +26,7 @@ class SimpleShapesDataModule(LightningDataModule):
         domain_classes: Mapping[DomainDesc, type[DataDomain]],
         domain_proportions: Mapping[frozenset[str], float],
         batch_size: int,
-        max_train_size: int = -1,
+        max_train_size: int | None = None,
         num_workers: int = 0,
         seed: int | None = None,
         ood_seed: int | None = None,
@@ -139,7 +139,7 @@ class SimpleShapesDataModule(LightningDataModule):
                     for domain_type, domain_cls in self.domain_classes.items()
                     if domain_type.kind == domain
                 },
-                self.max_train_size,
+                self.max_train_size or -1,
                 self._get_transforms([domain], split),
                 self.domain_args,
             )

--- a/simple_shapes_dataset/dataset/domain_alignment.py
+++ b/simple_shapes_dataset/dataset/domain_alignment.py
@@ -14,13 +14,14 @@ def get_alignment(
     split: str,
     domain_proportions: Mapping[frozenset[str], float],
     seed: int,
-    max_size: int,
+    max_size: int | None,
 ) -> Mapping[frozenset[str], np.ndarray]:
     assert split in ["train", "val", "test"]
 
     dataset_path = Path(dataset_path)
-    if max_size == -1:
+    if max_size is None:
         max_size = np.load(dataset_path / f"{split}_labels.npy").shape[0]
+    assert max_size is not None, "Error loading label file."
 
     alignment_split_name = get_deterministic_name(domain_proportions, seed, max_size)
 
@@ -37,7 +38,8 @@ def get_alignment(
             "Domain split not found. "
             "To create it, use `shapesd alignment add "
             f'--dataset_path "{str(dataset_path.resolve())}" '
-            f"--seed {seed} {' '.join(domain_alignment)}`"
+            f"--seed {seed} {' '.join(domain_alignment)} "
+            f"--ms {max_size}`"
         )
     domain_split: Mapping[frozenset[str], np.ndarray] = np.load(
         alignment_split_path, allow_pickle=True
@@ -52,7 +54,7 @@ def get_aligned_datasets(
     domain_classes: Mapping[DomainDesc, type[DataDomain]],
     domain_proportions: Mapping[frozenset[str], float],
     seed: int,
-    max_size: int = -1,
+    max_size: int | None = None,
     transforms: Mapping[str, Callable[[Any], Any]] | None = None,
     domain_args: Mapping[str, Any] | None = None,
 ) -> dict[frozenset[str], Subset]:
@@ -71,7 +73,7 @@ def get_aligned_datasets(
             dataset_path,
             split,
             sub_domain_cls,
-            max_size,
+            max_size or -1,
             transforms,
             domain_args,
         )

--- a/simple_shapes_dataset/dataset/downstream/odd_one_out/data_module.py
+++ b/simple_shapes_dataset/dataset/downstream/odd_one_out/data_module.py
@@ -64,7 +64,7 @@ class OddOneOutDataModule(LightningDataModule):
         domain_classes: Mapping[DomainDesc, type[DataDomain]],
         domain_proportions: Mapping[frozenset[str], float],
         batch_size: int,
-        max_train_size: int = -1,
+        max_train_size: int | None = None,
         num_workers: int = 0,
         seed: int | None = None,
         domain_args: Mapping[str, Any] | None = None,
@@ -138,7 +138,7 @@ class OddOneOutDataModule(LightningDataModule):
                 self.domain_classes,
                 self.domain_proportions,
                 self.seed,
-                self.max_train_size,
+                self.max_train_size or -1,
                 self._get_transforms(domains),
                 self.domain_args,
             )
@@ -162,7 +162,7 @@ class OddOneOutDataModule(LightningDataModule):
                     for domain_type, domain_cls in self.domain_classes.items()
                     if domain_type.kind == domain
                 },
-                self.max_train_size,
+                self.max_train_size or -1,
                 self._get_transforms([domain]),
                 self.domain_args,
             )

--- a/simple_shapes_dataset/types.py
+++ b/simple_shapes_dataset/types.py
@@ -114,7 +114,7 @@ class Exploration(BaseModel):
 
 class Dataset(BaseModel):
     path: Path
-    max_train_size: int = -1
+    max_train_size: int | None = 500_000
 
 
 class VisualModule(BaseModel):


### PR DESCRIPTION
Before it was all dataset - 1.

Also set the default max_train_size to 500_000 in the config.


**Breaking change:**
If you were using the default value before, it used all dataset - 1. Either re-generate the splits, or set `max_train_size: N` with your old value in the config.